### PR TITLE
Fix some include/libraries misuses

### DIFF
--- a/src/core/EpisodicTree/ArchivedLeafNode.cpp
+++ b/src/core/EpisodicTree/ArchivedLeafNode.cpp
@@ -283,7 +283,7 @@ void ArchivedLeafNode::loadStoredData()
 
   for(const auto& entry : std::experimental::filesystem::directory_iterator(directory_))
   {
-    std::string complete_dir = entry.path();
+    std::string complete_dir = entry.path().generic_string();
     std::string dir = complete_dir.substr(directory_.size());
     if(dir[0] == '/')
       dir.erase(dir.begin());

--- a/src/core/EpisodicTree/CompressedLeaf.cpp
+++ b/src/core/EpisodicTree/CompressedLeaf.cpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <regex>
+#include <sstream>
 
 #include "mementar/core/EpisodicTree/CompressedLeaf.h"
 

--- a/src/core/EpisodicTree/CompressedLeafNode.cpp
+++ b/src/core/EpisodicTree/CompressedLeafNode.cpp
@@ -341,7 +341,12 @@ bool CompressedLeafNode::loadStoredData()
 
   for(const auto& entry : std::experimental::filesystem::directory_iterator(directory_))
   {
-    std::string complete_dir = entry.path();
+    // std::filesystem::path to std::string conversion is platform-dependent:
+    //   it needs std::string on POSIX and std::wstring on Windows. Futhermore,
+    //   the directory separator change between operating systems.
+    // To solve this, we force the conversion to std::string ('/' is used as 
+    //   directory separator).
+    std::string complete_dir = entry.path().generic_string();
     std::string dir = complete_dir.substr(directory_.size());
     if(dir[0] == '/')
       dir.erase(dir.begin());

--- a/src/core/EpisodicTree/CompressedLeafSession.cpp
+++ b/src/core/EpisodicTree/CompressedLeafSession.cpp
@@ -1,6 +1,7 @@
 #include "mementar/core/EpisodicTree/CompressedLeafSession.h"
 
 #include <regex>
+#include <sstream>
 
 #include "mementar/core/archiving_compressing/compressing/LzUncompress.h"
 

--- a/src/core/EpisodicTree/Context.cpp
+++ b/src/core/EpisodicTree/Context.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <sstream>
 
 #include "mementar/core/utility/Display.h"
 

--- a/src/core/EpisodicTree/tests/archived_tree.cpp
+++ b/src/core/EpisodicTree/tests/archived_tree.cpp
@@ -3,7 +3,6 @@
 #include <stdlib.h>     /* srand, rand */
 #include <time.h>       /* time */
 #include <ctime>
-#include <unistd.h>
 
 #include "mementar/core/Btree/Btree.h"
 #include "mementar/core/EpisodicTree/ArchivedLeafNode.h"

--- a/src/core/EpisodicTree/tests/episodic_tree.cpp
+++ b/src/core/EpisodicTree/tests/episodic_tree.cpp
@@ -3,7 +3,6 @@
 #include <stdlib.h>     /* srand, rand */
 #include <time.h>       /* time */
 #include <ctime>
-#include <unistd.h>
 
 #include "mementar/core/EpisodicTree/CompressedLeaf.h"
 #include "mementar/core/Btree/Btree.h"

--- a/src/core/archiving_compressing/compressing/LzCompress.cpp
+++ b/src/core/archiving_compressing/compressing/LzCompress.cpp
@@ -1,5 +1,6 @@
 #include "mementar/core/archiving_compressing/compressing/LzCompress.h"
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
Add missing \<sstream\> and \<algorithm\> includes.
Remove unused and non cross-platform \<unistd\> includes.
Fix std::filesystem::path to std::string conversion for a safer cross-platform conversion.
